### PR TITLE
Adding "bench" test cases.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,11 +30,16 @@ Each JMESPath test case can have the following keys:
   against the ``given`` input.
 * ``error`` - The type of error that should be raised as a result of evaluating
   the JMESPath expression.
+* ``bench`` - If the case is a benchmark, ``bench`` contains the type of
+  benchmark. Available ``bench`` types are as follows:
+  * ``parse`` - Benchmark only the parsing of an expression.
+    ``interpret`` - Benchmark only the interpreting of an expression.
+    ``full`` - Benchmark both parsing and interepreting an expression.
 * ``comment`` - An optional comment containing a description of the specific
   test case.
 
-For each test case, either ``result`` or ``error`` must be specified.  Both
-keys cannot be present in a single test case.
+For each test case, either ``result``, ``error``, or ``bench`` must be
+specified.  Both keys cannot be present in a single test case.
 
 The error type (if the ``error`` key is present) indicates the type of error
 that an implementation should raise, but it does not indicate **when** this

--- a/tests/benchmarks.json
+++ b/tests/benchmarks.json
@@ -1,0 +1,124 @@
+[
+  {
+    "given": {
+      "long_name_for_a_field": true,
+      "a": {
+        "b": {
+          "c": {
+            "d": {
+              "e": {
+                "f": {
+                  "g": {
+                    "h": {
+                      "i": {
+                        "j": {
+                          "k": {
+                            "l": {
+                              "m": {
+                                "n": {
+                                  "o": {
+                                    "p": true
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "cases": [
+      {
+        "comment": "simple field",
+        "expression": "a",
+        "bench": "full"
+      },
+      {
+        "comment": "simple subexpression",
+        "expression": "a.b",
+        "bench": "full"
+      },
+      {
+        "comment": "deep field selection",
+        "expression": "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s",
+        "bench": "full"
+      },
+      {
+        "comment": "simple or",
+        "expression": "not_there || a",
+        "bench": "full"
+      }
+    ]
+  },
+  {
+    "given": {
+      "a":0,"b":1,"c":2,"d":3,"e":4,"f":5,"g":6,"h":7,"i":8,"j":9,"k":10,
+      "l":11,"m":12,"n":13,"o":14,"p":15,"q":16,"r":17,"s":18,"t":19,"u":20,
+      "v":21,"w":22,"x":23,"y":24,"z":25
+    },
+    "cases": [
+      {
+        "comment": "deep ands",
+        "expression": "a && b && c && d && e && f && g && h && i && j && k && l && m && n && o && p && q && r && s && t && u && v && w && x && y && z",
+        "bench": "full"
+      },
+      {
+        "comment": "deep ors",
+        "expression": "z || y || x || w || v || u || t || s || r || q || p || o || n || m || l || k || j || i || h || g || f || e || d || c || b || a",
+        "bench": "full"
+      },
+      {
+        "comment": "lots of summing",
+        "expression": "sum(z, y, x, w, v, u, t, s, r, q, p, o, n, m, l, k, j, i, h, g, f, e, d, c, b, a)",
+        "bench": "full"
+      },
+      {
+        "comment": "lots of multi list",
+        "expression": "[z, y, x, w, v, u, t, s, r, q, p, o, n, m, l, k, j, i, h, g, f, e, d, c, b, a]",
+        "bench": "full"
+      }
+    ]
+  },
+  {
+    "given": {},
+    "cases": [
+      {
+        "comment": "field 50",
+        "expression": "j49.j48.j47.j46.j45.j44.j43.j42.j41.j40.j39.j38.j37.j36.j35.j34.j33.j32.j31.j30.j29.j28.j27.j26.j25.j24.j23.j22.j21.j20.j19.j18.j17.j16.j15.j14.j13.j12.j11.j10.j9.j8.j7.j6.j5.j4.j3.j2.j1.j0",
+        "bench": "parse"
+      },
+      {
+        "comment": "pipe 50",
+        "expression": "j49|j48|j47|j46|j45|j44|j43|j42|j41|j40|j39|j38|j37|j36|j35|j34|j33|j32|j31|j30|j29|j28|j27|j26|j25|j24|j23|j22|j21|j20|j19|j18|j17|j16|j15|j14|j13|j12|j11|j10|j9|j8|j7|j6|j5|j4|j3|j2|j1|j0",
+        "bench": "parse"
+      },
+      {
+        "comment": "index 50",
+        "expression": "[49][48][47][46][45][44][43][42][41][40][39][38][37][36][35][34][33][32][31][30][29][28][27][26][25][24][23][22][21][20][19][18][17][16][15][14][13][12][11][10][9][8][7][6][5][4][3][2][1][0]",
+        "bench": "parse"
+      },
+      {
+        "comment": "long raw string literal",
+        "expression": "'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'",
+        "bench": "parse"
+      },
+      {
+        "comment": "deep projection 104",
+        "expression": "a[*].b[*].c[*].d[*].e[*].f[*].g[*].h[*].i[*].j[*].k[*].l[*].m[*].n[*].o[*].p[*].q[*].r[*].s[*].t[*].u[*].v[*].w[*].x[*].y[*].z[*].a[*].b[*].c[*].d[*].e[*].f[*].g[*].h[*].i[*].j[*].k[*].l[*].m[*].n[*].o[*].p[*].q[*].r[*].s[*].t[*].u[*].v[*].w[*].x[*].y[*].z[*].a[*].b[*].c[*].d[*].e[*].f[*].g[*].h[*].i[*].j[*].k[*].l[*].m[*].n[*].o[*].p[*].q[*].r[*].s[*].t[*].u[*].v[*].w[*].x[*].y[*].z[*].a[*].b[*].c[*].d[*].e[*].f[*].g[*].h[*].i[*].j[*].k[*].l[*].m[*].n[*].o[*].p[*].q[*].r[*].s[*].t[*].u[*].v[*].w[*].x[*].y[*].z[*]",
+        "bench": "parse"
+      },
+      {
+        "comment": "filter projection",
+        "expression": "foo[bar > baz][qux > baz]",
+        "bench": "parse"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This commit adds the concept of benchmarks to the JMESPath test suite. A test case may now be based on a "result", "error", or "bench". Available bench types are "parse", "interpret", or "full".
1. What do you think about the idea in general?
2. Do you have any suggestions for how the benchmarks I've added can be improved? What's missing / what's extraneous or could be better?
3. One thing that's possible, but not necessarily something we need to do, is intersperse the benchmarks in the associated test files. Test cases of `bench` don't have to all be in the same JSON file, so adding them throughout is a possibility. What do you think of interspersing the benchmarks vs keeping them in a single `benchmarks.json` file?

Here's an example of the [jmespath.rs implementation's](https://github.com/mtdowling/jmespath.rs/blob/master/build.rs#L94) output:

![image](https://cloud.githubusercontent.com/assets/190930/12409853/0b1b9bc0-be23-11e5-9e53-aebbea144219.png)

In the Rust implementation, I chose to benchmark `full` as interpreted, parsed, and then the full aggregate of all phases.
