### PR TITLE
Adding test for multi-select-hash from null

### DIFF
--- a/tests/multiselect.json
+++ b/tests/multiselect.json
@@ -387,6 +387,11 @@
           "comment": "Nested multiselect",
           "expression": "[[*]]",
           "result": [[]]
+        },
+        {
+          "comment": "Select on null",
+          "expression": "missing.{foo: bar}",
+          "result": null
         }
     ]
 }


### PR DESCRIPTION
I noticed that this is a missing test case when doing code coverage analysis on jmespath.rs: https://coveralls.io/builds/4784504/source?filename=src%2Finterpreter.rs#L200
