### PR TITLE
Add tests that cover backslashes in raw strings

### DIFF
--- a/tests/literal.json
+++ b/tests/literal.json
@@ -184,6 +184,16 @@
           "comment": "Can escape the single quote",
           "expression": "'foo\\'bar'",
           "result": "foo'bar"
+        },
+        {
+          "comment": "Backslash not followed by single quote is treated as any other character",
+          "expression": "'\\z'",
+          "result": "\\z"
+        },
+        {
+          "comment": "Backslash not followed by single quote is treated as any other character",
+          "expression": "'\\\\'",
+          "result": "\\\\"
         }
       ]
     }


### PR DESCRIPTION
The official grammar does not allow backslashes in raw strings except when followed by single quote, however there are compliance tests that require backslashes to be treated as any other character, and jp seem to work that way.

This is related to jmespath/jmespath.site#26
