### PR TITLE
Add ordering and parser compliance cases

### DIFF
--- a/tests/functions.json
+++ b/tests/functions.json
@@ -837,5 +837,95 @@
       "result": [[1, 2, 3, 4], [5, 6, 7, 8, 9]]
     }
   ]
+}, {
+  "given": {
+    "negatives": [-1, -2, 3],
+    "floats": [0.6058, 0.20155, 0.63554],
+    "sci": [1e20, 5],
+    "prefixed_strings": ["x10", "x2", "x1"],
+    "numeric_strings": ["10", "9", "2"],
+    "zero_padded_strings": ["1", "01", "001"],
+    "two_numeric_strings": ["10", "9"],
+    "records": [
+         {"v": "A", "w": 0.63554},
+         {"v": "B", "w": 0.20155},
+         {"v": "C", "w": 0.6058}
+    ],
+    "keyed_strings": [
+         {"key": "10", "tag": "first"},
+         {"key": "9", "tag": "second"}
+    ],
+    "mixed_keys": [
+         {"key": 1},
+         {"key": "a"}
+    ]
+  },
+  "cases": [
+    {
+      "comment": "sort negative numbers numerically",
+      "expression": "sort(negatives)",
+      "result": [-2, -1, 3]
+    },
+    {
+      "comment": "sort fractions whose smaller value has the longer digit run",
+      "expression": "sort(floats)",
+      "result": [0.20155, 0.6058, 0.63554]
+    },
+    {
+      "comment": "sort numbers in scientific notation numerically",
+      "expression": "sort(sci)",
+      "result": [5, 1e20]
+    },
+    {
+      "comment": "sort strings by code point, not natural order",
+      "expression": "sort(prefixed_strings)",
+      "result": ["x1", "x10", "x2"]
+    },
+    {
+      "comment": "sort numeric strings by code point",
+      "expression": "sort(numeric_strings)",
+      "result": ["10", "2", "9"]
+    },
+    {
+      "comment": "sort zero padded strings by code point, no ties",
+      "expression": "sort(zero_padded_strings)",
+      "result": ["001", "01", "1"]
+    },
+    {
+      "comment": "sort_by compares float keys numerically",
+      "expression": "sort_by(records, &w)[].v",
+      "result": ["B", "C", "A"]
+    },
+    {
+      "comment": "max of numeric strings uses code point order",
+      "expression": "max(two_numeric_strings)",
+      "result": "9"
+    },
+    {
+      "comment": "min of numeric strings uses code point order",
+      "expression": "min(two_numeric_strings)",
+      "result": "10"
+    },
+    {
+      "comment": "max_by with numeric string keys uses code point order",
+      "expression": "max_by(keyed_strings, &key)",
+      "result": {"key": "9", "tag": "second"}
+    },
+    {
+      "comment": "min_by with numeric string keys uses code point order",
+      "expression": "min_by(keyed_strings, &key)",
+      "result": {"key": "10", "tag": "first"}
+    },
+    {
+      "comment": "max_by rejects mixed number and string keys",
+      "expression": "max_by(mixed_keys, &key)",
+      "error": "invalid-type"
+    },
+    {
+      "comment": "min_by rejects mixed number and string keys",
+      "expression": "min_by(mixed_keys, &key)",
+      "error": "invalid-type"
+    }
+  ]
 }
 ]

--- a/tests/syntax.json
+++ b/tests/syntax.json
@@ -688,5 +688,23 @@
           "result": [null]
         }
     ]
+  },
+  {
+    "comment": "Invalid tokens after a complete expression",
+    "given": {"type": "object"},
+    "cases": [
+        {
+          "expression": "avg([].size)+",
+          "error": "syntax"
+        },
+        {
+          "expression": "foo[]+",
+          "error": "syntax"
+        },
+        {
+          "expression": "a = b",
+          "error": "syntax"
+        }
+    ]
   }
 ]


### PR DESCRIPTION
Adds fixtures for shapes the corpus currently passes by coincidence: sort()/sort_by() numeric ordering (negatives, uneven fraction digit runs, scientific notation), code-point string ordering where natural order differs, max()/min()/max_by()/min_by() over numeric strings, mixed-type *_by keys, and led-position invalid-token syntax errors.

Heads-up: the mixed-key cases currently raise a raw TypeError in jmespath.py, and the numeric sort cases fail on jmespath.js (its sort() string-sorts numbers). The PHP implementation passes these test cases.